### PR TITLE
TCP Connection Refactoring

### DIFF
--- a/AdapterInterface/Adapter.cs
+++ b/AdapterInterface/Adapter.cs
@@ -124,11 +124,14 @@ namespace Mtconnect
         /// Generic constructor of a new Adapter instance with basic AdapterOptions.
         /// </summary>
         /// <param name="options"><inheritdoc cref="AdapterOptions" path="/summary"/></param>
-        public Adapter(AdapterOptions options)
+        /// <param name="loggerFactory">Reference to the logger factory to handle logging.</param>
+        public Adapter(AdapterOptions options, ILogger<Adapter> logger = null)
         {
             _options = options;
             Heartbeat = options.Heartbeat;
             CanEnqueueDataItems = options.CanEnqueueDataItems;
+
+            _logger = logger;
         }
 
         /// <summary>
@@ -319,11 +322,11 @@ namespace Mtconnect
             Write(sb.ToString());
         }
         
-        /// <summary>
-        /// The heartbeat thread for a client. This thread receives data from a client, closes the socket when it fails, and handles communication timeouts when the client does not send a heartbeat within 2x the heartbeat frequency. When the heartbeat is not received, the client is assumed to be unresponsive and the connection is closed. Waits for one ping to be received before enforcing the timeout. 
-        /// </summary>
-        /// <param name="client">The client we are communicating with.</param>
-        protected abstract void HeartbeatClient(object client);
+        ///// <summary>
+        ///// The heartbeat thread for a client. This thread receives data from a client, closes the socket when it fails, and handles communication timeouts when the client does not send a heartbeat within 2x the heartbeat frequency. When the heartbeat is not received, the client is assumed to be unresponsive and the connection is closed. Waits for one ping to be received before enforcing the timeout. 
+        ///// </summary>
+        ///// <param name="client">The client we are communicating with.</param>
+        //protected abstract void HeartbeatClient(object client);
 
         /// <summary>
         /// Start the listener thread.

--- a/AdapterInterface/Adapter.cs
+++ b/AdapterInterface/Adapter.cs
@@ -274,6 +274,8 @@ namespace Mtconnect
         /// <param name="values">Collection of <see cref="ReportedValue"/>s to send values.</param>
         protected void Send(IEnumerable<ReportedValue> values, string clientId = null)
         {
+            _logger?.LogTrace($"Sending {values.Count()} values");
+
             var orderedValues = values.OrderBy(o => o.Timestamp).ToList();
             var individualValues = values.Where(o => o.HasNewLine).ToList();
             var multiplicityValues = orderedValues.Except(individualValues).ToList();

--- a/AdapterInterface/AdapterExtensions.cs
+++ b/AdapterInterface/AdapterExtensions.cs
@@ -1,0 +1,139 @@
+﻿using Mtconnect.AdapterInterface.Contracts.Attributes;
+using Mtconnect.AdapterInterface.DataItems;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Mtconnect
+{
+    public static class AdapterExtensions
+    {
+        /// <summary>
+        /// Attempts to add a <paramref name="dataItem"/> to the <paramref name="adapter"/> if the adapter does not already contain such a <see cref="DataItem"/>.
+        /// </summary>
+        /// <param name="adapter">Reference to the adapter to add the data item onto.</param>
+        /// <param name="dataItem">Reference to the data item to be added.</param>
+        /// <returns>Flag for whether or not the data item has been added. Returns true if the data item has already been added.</returns>
+        public static bool TryAddDataItem(this Adapter adapter, DataItem dataItem)
+        {
+            if (adapter.Contains(dataItem)) return true;
+
+            adapter.AddDataItem(dataItem);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Adds Data Items from properties in the <paramref name="model"/> that are decorated with the <see cref="DataItemAttribute"/>.
+        /// </summary>
+        /// <param name="adapter">Reference to the MTConnect <see cref="Adapter"/> to add the data items onto.</param>
+        /// <param name="model">Reference to a data model containing <see cref="DataItemAttribute"/>s.</param>
+        /// <returns>Flag for whether or not all decorated <see cref="DataItemAttribute"/>s were added to the adapter.</returns>
+        public static bool TryAddDataItems(this Adapter adapter, IAdapterDataModel model)
+        {
+            return adapter.TryAddDataItems(model.GetType());
+        }
+        private static PropertyInfo[] GetDataItemProperties(Type type)
+        {
+            return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(o => o.GetCustomAttribute(typeof(DataItemAttribute)) != null)
+                .ToArray();
+        }
+        private static Dictionary<Type, PropertyInfo[]> _dataItemProperties = new Dictionary<Type, PropertyInfo[]>();
+        private static bool TryAddDataItems(this Adapter adapter, Type dataModelType, string dataItemNamePrefix = "")
+        {
+            if (_dataItemProperties.TryGetValue(dataModelType, out PropertyInfo[] dataItemProperties)) return true;
+
+            dataItemProperties = GetDataItemProperties(dataModelType);
+            _dataItemProperties.Add(dataModelType, dataItemProperties);
+            bool allDataItemsAdded = true;
+
+
+            foreach (var property in dataItemProperties)
+            {
+                bool dataItemAdded = false;
+                var dataItemAttribute = property.GetCustomAttribute<DataItemAttribute>();
+                string dataItemName = dataItemNamePrefix + dataItemAttribute.Name;
+
+                switch (dataItemAttribute)
+                {
+                    case DataItemPartialAttribute _:
+                        dataItemAdded = adapter.TryAddDataItems(property.PropertyType, dataItemName);
+                        break;
+                    case EventAttribute _:
+                        dataItemAdded = adapter.TryAddDataItem(new Event(dataItemName));
+                        break;
+                    case SampleAttribute _:
+                        dataItemAdded = adapter.TryAddDataItem(new Sample(dataItemName));
+                        break;
+                    case ConditionAttribute _:
+                        dataItemAdded = adapter.TryAddDataItem(new Condition(dataItemName));
+                        break;
+                    case TimeSeriesAttribute _:
+                        dataItemAdded = adapter.TryAddDataItem(new TimeSeries(dataItemName));
+                        break;
+                    case MessageAttribute _:
+                        dataItemAdded = adapter.TryAddDataItem(new Message(dataItemName));
+                        break;
+                    default:
+                        dataItemAdded = false;
+                        break;
+                }
+
+                if (!dataItemAdded) allDataItemsAdded = false;
+            }
+
+            return allDataItemsAdded;
+        }
+
+        /// <summary>
+        /// Attempts to update the <see cref="DataItem"/>s of the <paramref name="adapter"/>.
+        /// </summary>
+        /// <param name="adapter">Reference to the MTConnect <see cref="Adapter"/> to update the data items from.</param>
+        /// <param name="model">Reference to the data model to update the <paramref name="adapter"/>s <see cref="DataItem"/>s from.</param>
+        /// <returns>Flag for whether or not all <see cref="DataItem"/> values were updated from the <paramref name="model"/>.</returns>
+        public static bool TryUpdateValues(this Adapter adapter, IAdapterDataModel model)
+        {
+            return TryUpdateValues(adapter, model, string.Empty);
+        }
+        private static bool TryUpdateValues(this Adapter adapter, object model, string dataItemPrefix)
+        {
+            bool allDataItemsUpdated = true;
+
+            Type sourceType = model.GetType();
+
+            if (!_dataItemProperties.TryGetValue(sourceType, out PropertyInfo[] dataItemProperties))
+            {
+                dataItemProperties = GetDataItemProperties(sourceType);
+            }
+            foreach (var property in dataItemProperties)
+            {
+                bool dataItemUpdated = true;
+
+                var dataItemAttribute = property.GetCustomAttribute<DataItemAttribute>();
+                string dataItemName = dataItemPrefix + dataItemAttribute.Name;
+                switch (dataItemAttribute)
+                {
+                    case DataItemPartialAttribute _:
+                        dataItemUpdated = adapter.TryUpdateValues(property.GetValue(model), dataItemName);
+                        break;
+                    case EventAttribute _:
+                    case SampleAttribute _:
+                    case ConditionAttribute _:
+                    case TimeSeriesAttribute _:
+                    case MessageAttribute _:
+                        adapter[dataItemName].Value = property.GetValue(model);
+                        break;
+                    default:
+                        dataItemUpdated = false;
+                        break;
+                }
+
+                if (!dataItemUpdated) allDataItemsUpdated = false;
+            }
+
+            return allDataItemsUpdated;
+        }
+    }
+}

--- a/AdapterInterface/AdapterInterface.csproj
+++ b/AdapterInterface/AdapterInterface.csproj
@@ -17,11 +17,11 @@
     <PackageIcon>icon.jpg</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>MTConnect;Adapter;Interface</PackageTags>
-    <PackageReleaseNotes>Introduction of encryption of scripts within the App.config. These scripts can be used to transform the Data Item values.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added extra logging and refactored DataItem modeling.</PackageReleaseNotes>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>1.0.7-alpha</Version>
+    <Version>1.0.8-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AdapterInterface/IAdapterDataModel.cs
+++ b/AdapterInterface/IAdapterDataModel.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading;
+
+namespace Mtconnect
+{
+    /// <summary>
+    /// A generic interface for instantiating a source for a MTConnect Adapter.
+    /// </summary>
+    public interface IAdapterDataModel
+    {
+    }
+}

--- a/AdapterInterface/IAdapterSource.cs
+++ b/AdapterInterface/IAdapterSource.cs
@@ -1,15 +1,17 @@
-﻿
+﻿using System;
+using System.Threading;
+
 namespace Mtconnect
 {
     /// <summary>
     /// Handler for ingesting data from a MTConnect Adapter source.
     /// </summary>
-    /// <param name="sender">Reference to the Adapter source.</param>
+    /// <param name="data">Reference to the data model.</param>
     /// <param name="e">Event arguments containing data received from the MTConnect Adapter source.</param>
-    public delegate void DataReceivedHandler(object sender, DataReceivedEventArgs e);
+    public delegate void DataReceivedHandler(IAdapterDataModel data, DataReceivedEventArgs e);
 
     /// <summary>
-    /// A generic interface for instantiating a source for a MTConnect Adapter.
+    /// A generic interface for classes used to derive <see cref="Mtconnect.AdapterInterface.Contracts.Attributes.DataItemAttribute"/>s from use.
     /// </summary>
     public interface IAdapterSource
     {
@@ -21,10 +23,11 @@ namespace Mtconnect
         /// <summary>
         /// Instructs the Adapter source to begin collecting data.
         /// </summary>
-        void Start();
+        /// <param name="token">Token for cancelling the startup method.</param>
+        void Start(CancellationToken token = default);
 
         /// <summary>
-        /// Instructs the Adapter source to stop collecting data.
+        /// Instructs the Adapter source to stop collecting and/or processing data.
         /// </summary>
         void Stop();
     }

--- a/MtconnectCore.TcpAdapter/TcpAdapter.cs
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -15,7 +17,7 @@ namespace Mtconnect
     /// <summary>
     /// An implementation of a MTConnect Adapter that publishes data thru a TCP stream.
     /// </summary>
-    public sealed class TcpAdapter : Adapter
+    public sealed class TcpAdapter : Adapter, IDisposable
     {
         /// <summary>
         /// The Port property to set and get the mPort. This will only take affect when the adapter is stopped.
@@ -23,32 +25,38 @@ namespace Mtconnect
         public int Port { get; private set; } = 7878;
 
         /// <summary>
+        /// The maximum number of kvp connections allowed to exist at any given point.
+        /// </summary>
+        public int MaxConnections { get; private set; } = 1;
+
+        /// <summary>
         /// The listening thread for new connections
         /// </summary>
         private Thread _listenerThread;
 
         /// <summary>
-        /// A list of all the client connections.
+        /// A list of all the kvp connections.
         /// </summary>
-        private Dictionary<string, Stream> _clients = new Dictionary<string, Stream>();
+        private ConcurrentDictionary<string, TcpConnection> _clients { get; set; } = new ConcurrentDictionary<string, TcpConnection>();
 
         /// <summary>
-        /// A count of client threads.
+        /// A count of kvp threads.
         /// </summary>
-        private CountdownEvent _activeClients = new CountdownEvent(1);
+        private CountdownEvent _activeClients { get; set; } = new CountdownEvent(1);
 
         /// <summary>
         /// The server socket.
         /// </summary>
-        private TcpListener _listener;
+        private TcpListener _listener { get; set; }
 
         /// <summary>
         /// Constructs a new <see cref="TcpAdapter"/>.
         /// </summary>
         /// <param name="options"><inheritdoc cref="TcpAdapterOptions" path="/summary"/></param>
-        public TcpAdapter(TcpAdapterOptions options) : base(options)
+        public TcpAdapter(TcpAdapterOptions options, ILogger<Adapter> logger = null) : base(options, logger)
         {
             Port = options.Port;
+            MaxConnections = options.MaxConcurrentConnections;
         }
 
         /// <inheritdoc />
@@ -81,14 +89,13 @@ namespace Mtconnect
                 // Wait 2 seconds for the thread to exit.
                 _listenerThread.Join((int)(2 * Heartbeat));
 
-                foreach (Object obj in _clients)
+                foreach (var kvp in _clients)
                 {
-                    Stream client = (Stream)obj;
-                    client.Close();
+                    kvp.Value.Dispose();
                 }
                 _clients.Clear();
 
-                // Wait for all client threads to exit.
+                // Wait for all kvp threads to exit.
                 _activeClients.Wait(2000);
 
                 State = AdapterStates.Stopped;
@@ -111,38 +118,28 @@ namespace Mtconnect
             HasBegun = false;
         }
 
-#if DEBUG
-        /// <summary>
-        /// For testing, add a io stream to the adapter.
-        /// </summary>
-        /// <param name="clientId">The client who sent the text</param>
-        /// <param name="aStream">A IO Stream</param>
-        public void addClientStream(string clientId, Stream aStream)
-        {
-            _clients.Add(clientId, aStream);
-            Send(DataItemSendTypes.All, clientId);
-        }
-#endif
-
         /// <inheritdoc />
         protected override void Write(string message, string clientId = null)
         {
             _logger?.LogDebug("Sending message: {Message}", message);
-
-            if (clientId == null)
+            lock(_clients)
             {
-                foreach (var kvp in _clients)
+                if (_clients.Any())
                 {
-                    lock (kvp.Value)
+                    if (clientId == null)
                     {
-                        WriteToClient(kvp.Key, message);
+                        foreach (var kvp in _clients)
+                        {
+                            kvp.Value.Write(message);
+                        }
                     }
-                }
-            } else if (_clients.ContainsKey(clientId))
-            {
-                lock (_clients[clientId])
-                {
-                    WriteToClient(clientId, message);
+                    else if (_clients.TryGetValue(clientId, out var client) && client != null)
+                    {
+                        lock (client)
+                        {
+                            client.Write(message);
+                        }
+                    }
                 }
             }
         }
@@ -155,179 +152,6 @@ namespace Mtconnect
         {
             foreach (var kvp in _clients)
                 kvp.Value.Flush();
-
-        }
-
-        /// <summary>
-        /// Receive data from a client and implement heartbeat ping/pong protocol.
-        /// </summary>
-        /// <param name="clientId">The client who sent the text</param>
-        /// <param name="line">The line of text</param>
-        private bool Receive(string clientId, string line)
-        {
-            Stream clientStream = null;
-            if (!_clients.TryGetValue(clientId, out clientStream))
-                return false;
-
-            bool heartbeat = false;
-            // TODO: Implement const for * PING
-            if (line.StartsWith("* PING") && Heartbeat > 0)
-            {
-                heartbeat = true;
-                lock (clientStream)
-                {
-                    _logger?.LogDebug("Received PING, sending PONG");
-                    WriteToClient(clientId, PONG);
-                    clientStream.Flush();
-                }
-            }
-
-            return heartbeat;
-        }
-        
-        /// <summary>
-        /// Send text to a client as a byte array. Handles execptions and remove the client from the list of clients if the write fails. Also makes sure the client connection is closed when it fails.
-        /// </summary>
-        /// <param name="clientId">Reference to the registered client id for the TCP stream.</param>
-        /// <param name="message">The message to send to the client.</param>
-        private void WriteToClient(string clientId, string message) => WriteToClient(clientId, Encoder.GetBytes(message.ToCharArray()));
-
-        /// <summary>
-        /// Send text to a client as a byte array. Handles execptions and remove the client from the list of clients if the write fails. Also makes sure the client connection is closed when it fails.
-        /// </summary>
-        /// <param name="clientId">The client to send the message to</param>
-        /// <param name="message">The message</param>
-        private void WriteToClient(string clientId, byte[] message)
-        {
-            Stream clientStream = null;
-            try
-            {
-                if (_clients.TryGetValue(clientId, out clientStream))
-                {
-                    clientStream.Write(message, 0, message.Length);
-                } else
-                {
-                    _logger?.LogWarning("Could not find client from id '{clientId}'", clientId);
-                }
-            }
-            catch (Exception e)
-            {
-                // TODO: Convert to constant
-                _logger?.LogError(e, "Failed to write to client stream");
-                try
-                {
-                    clientStream?.Close();
-                }
-                catch (Exception f)
-                {
-                    _logger?.LogError(f, "Failed to close client stream");
-                } finally
-                {
-                    if (_clients.ContainsKey(clientId))
-                        _clients.Remove(clientId);
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        protected override void HeartbeatClient(object client)
-        {
-            _activeClients.AddCount();
-            TcpClient tcpClient = (TcpClient)client;
-            NetworkStream clientStream = tcpClient.GetStream();
-            string clientId = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
-
-            if (!_clients.ContainsKey(clientId))
-                _clients.Add(clientId, null);
-            _clients[clientId] = clientStream;
-
-            ArrayList readList = new ArrayList();
-            bool heartbeatActive = false;
-
-            byte[] message = new byte[4096];
-            int length = 0;
-
-            try
-            {
-                while (State == AdapterStates.Busy && tcpClient.Connected)
-                {
-                    int bytesRead = 0;
-
-                    try
-                    {
-                        readList.Clear();
-                        readList.Add(tcpClient.Client);
-                        if (Heartbeat > 0 && heartbeatActive)
-                            Socket.Select(readList, null, null, (int)(Heartbeat * 2000));
-                        if (readList.Count == 0 && heartbeatActive)
-                        {
-                            _logger?.LogWarning("Heartbeat timed out, closing connection");
-                            break;
-                        }
-
-                        //blocks until a client sends a message
-                        bytesRead = clientStream.Read(message, length, 4096 - length);
-                    }
-                    catch (Exception e)
-                    {
-                        //a socket error has occured
-                        _logger?.LogError(e, "Failed to read heartbeat client message");
-                        break;
-                    }
-
-                    if (bytesRead == 0)
-                    {
-                        //the client has disconnected from the server
-                        _logger?.LogWarning("No bytes were read from heartbeat client");
-                        break;
-                    }
-
-                    // See if we have a line
-                    int pos = length;
-                    length += bytesRead;
-                    int eol = 0;
-                    for (int i = pos; i < length; i++)
-                    {
-                        if (message[i] == '\n')
-                        {
-
-                            String line = Encoder.GetString(message, eol, i);
-                            if (Receive(clientId, line)) heartbeatActive = true;
-                            eol = i + 1;
-                        }
-                    }
-
-                    // Remove the lines that have been processed.
-                    if (eol > 0)
-                    {
-                        length = length - eol;
-                        // Shift the message array to remove the lines.
-                        if (length > 0)
-                            Array.Copy(message, eol, message, 0, length);
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                _logger?.LogError(e, "Failed to process heartbeat client");
-            }
-
-            finally
-            {
-                try
-                {
-                    if (_clients.ContainsKey(clientId))
-                    {
-                        _clients.Remove(clientId);
-                    }
-                    tcpClient.Close();
-                }
-                catch (Exception e)
-                {
-                    _logger?.LogError(e, "Failed to cleanup heartbeat client connection");
-                }
-                _activeClients.Signal();
-            }
         }
 
         /// <summary>
@@ -341,18 +165,40 @@ namespace Mtconnect
             {
                 while (State == AdapterStates.Busy)
                 {
-                    //blocks until a client has connected to the server
-                    TcpClient tcpClient = _listener.AcceptTcpClient();
-                    string clientId = ((IPEndPoint)tcpClient.Client.RemoteEndPoint).Address.ToString();
+                    if (!_listener.Pending()) continue;
 
-                    //create a thread to handle communication 
-                    //with connected client
-                    Thread clientThread = new Thread(new ParameterizedThreadStart(HeartbeatClient));
-                    clientThread.Start(tcpClient);
+                    //blocks until a kvp has connected to the server
+                    var client = new TcpConnection(_listener.AcceptTcpClient(), (int)Heartbeat);
+                    if (_activeClients.CurrentCount >= MaxConnections)
+                    {
+                        _logger?.LogWarning(
+                            "Denied connection to '{ClientId}', too many concurrent connections ({ActiveConnections}/{MaxConnections})",
+                            client.ClientId,
+                            _activeClients.CurrentCount,
+                            MaxConnections
+                        );
+                        continue;
+                    }
 
-                    // Issue command for underlying Adapter to send all DataItem current values to the newly added client
-                    Send(DataItemSendTypes.All, clientId);
-                    clientThread.Join();
+                    if (!_clients.ContainsKey(client.ClientId) && _activeClients.TryAddCount())
+                    {
+                        _logger?.LogInformation("New client connection '{ClientId}'", client.ClientId);
+                        if (_clients.TryAdd(client.ClientId, client))
+                        {
+                            client.OnDisconnected += Client_OnConnectionDisconnected;
+                            client.OnDataReceived += Client_OnReceivedData;
+                            client.Connect();
+                            // Issue command for underlying Adapter to send all DataItem current values to the newly added kvp
+                            Send(DataItemSendTypes.All, client.ClientId);
+                        } else
+                        {
+                            _activeClients.Signal(); // Undo try add
+                            _logger?.LogError("Failed to add client '{ClientId}'", client.ClientId);
+                        }
+                    } else
+                    {
+                        _logger?.LogWarning("Client '{ClientId}' already has an established connection", client.ClientId);
+                    }
                 }
             }
             catch (Exception e)
@@ -364,6 +210,57 @@ namespace Mtconnect
                 State = AdapterStates.Started;
                 _listener.Stop();
             }
+        }
+
+        private const string PING = "* PING";
+        /// <summary>
+        /// ReceiveClient data from a kvp and implement heartbeat ping/pong protocol.
+        /// </summary>
+        private bool Client_OnReceivedData(TcpConnection connection, string message)
+        {
+            bool heartbeat = false;
+            if (message.StartsWith(PING) && Heartbeat > 0)
+            {
+                heartbeat = true;
+                lock (connection)
+                {
+                    _logger?.LogInformation("Received PING from client {ClientId}, sending PONG", connection.ClientId);
+                    connection.Write(PONG);
+                    connection.Flush();
+                }
+            }
+
+            return heartbeat;
+        }
+
+        private void Client_OnConnectionDisconnected(TcpConnection connection)
+        {
+            if (_clients.ContainsKey(connection.ClientId))
+            {
+                lock(_clients)
+                {
+                    _logger?.LogInformation("Client disconnected '{ClientId}'", connection.ClientId);
+                    if (_clients.TryRemove(connection.ClientId, out TcpConnection client))
+                    {
+                        if (_activeClients.Signal())
+                        {
+                            _logger?.LogInformation("No clients connected");
+                        }
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var kvp in _clients)
+            {
+                kvp.Value.Dispose();
+            }
+            _clients.Clear();
+
+            _listener.Stop();
+
         }
     }
 }

--- a/MtconnectCore.TcpAdapter/TcpAdapter.cs
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.cs
@@ -64,6 +64,7 @@ namespace Mtconnect
         {
             if (State <= AdapterStates.NotStarted)
             {
+                _logger?.LogInformation("Starting Adapter");
                 State = AdapterStates.Starting;
 
                 _listener = new TcpListener(IPAddress.Any, Port);
@@ -84,6 +85,7 @@ namespace Mtconnect
 
             if (State > AdapterStates.NotStarted)
             {
+                _logger?.LogInformation("Stopping Adapter");
                 State = AdapterStates.Stopping;
 
                 // Wait 2 seconds for the thread to exit.

--- a/MtconnectCore.TcpAdapter/TcpAdapter.csproj
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.csproj
@@ -18,8 +18,8 @@
 	  <RepositoryUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</RepositoryUrl>
 	  <RepositoryType>git</RepositoryType>
 	  <PackageTags>Mtconnect;Adapter;TCP;TAMS;</PackageTags>
-	  <PackageReleaseNotes>An implementation of the generic MTConnect&amp;reg; Adapter library that listens for TCP clients and publishes data in a pipe-delimitted stream.</PackageReleaseNotes>
-	  <Version>1.0.7-alpha</Version>
+	  <PackageReleaseNotes>Added extra logging and refined TcpConnections.</PackageReleaseNotes>
+	  <Version>1.0.8-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MtconnectCore.TcpAdapter/TcpAdapterOptions.cs
+++ b/MtconnectCore.TcpAdapter/TcpAdapterOptions.cs
@@ -15,13 +15,19 @@ namespace Mtconnect
         public int Port { get; private set; }
 
         /// <summary>
+        /// The maximum number of connections allowed at any given point.
+        /// </summary>
+        public int MaxConcurrentConnections { get; private set; }
+
+        /// <summary>
         /// Constructs the most basic options for configuring a MTConnect Adapter.
         /// </summary>
         /// <param name="heartbeat"><inheritdoc cref="AdapterOptions.AdapterOptions" path="/param[@name='heartbeat']"/></param>
         /// <param name="port"><inheritdoc cref="TcpAdapterOptions.Port" path="/summary"/></param>
-        public TcpAdapterOptions(double heartbeat = 10_000, int port = 7878) : base(heartbeat)
+        public TcpAdapterOptions(double heartbeat = 10_000, int port = 7878, int maxConnections = 1) : base(heartbeat)
         {
             Port = port;
+            MaxConcurrentConnections = maxConnections;
         }
 
         public override Dictionary<string, object> UpdateFromConfig()
@@ -31,6 +37,11 @@ namespace Mtconnect
             if (adapterSettings.ContainsKey("port") && Int32.TryParse(adapterSettings["port"].ToString(), out int port))
             {
                 Port = port;
+            }
+
+            if (adapterSettings.ContainsKey("maxConnections") && Int32.TryParse(adapterSettings["maxConnections"].ToString(), out int maxConnections))
+            {
+                MaxConcurrentConnections = maxConnections;
             }
 
             return adapterSettings;

--- a/MtconnectCore.TcpAdapter/TcpAdapterOptions.cs
+++ b/MtconnectCore.TcpAdapter/TcpAdapterOptions.cs
@@ -24,7 +24,7 @@ namespace Mtconnect
         /// </summary>
         /// <param name="heartbeat"><inheritdoc cref="AdapterOptions.AdapterOptions" path="/param[@name='heartbeat']"/></param>
         /// <param name="port"><inheritdoc cref="TcpAdapterOptions.Port" path="/summary"/></param>
-        public TcpAdapterOptions(double heartbeat = 10_000, int port = 7878, int maxConnections = 1) : base(heartbeat)
+        public TcpAdapterOptions(double heartbeat = 10_000, int port = 7878, int maxConnections = 2) : base(heartbeat)
         {
             Port = port;
             MaxConcurrentConnections = maxConnections;

--- a/MtconnectCore.TcpAdapter/TcpConnection.cs
+++ b/MtconnectCore.TcpAdapter/TcpConnection.cs
@@ -61,7 +61,8 @@ namespace Mtconnect
         {
             _client = client;
             Heartbeat = heartbeat;
-            ClientId = ((IPEndPoint)_client.Client.RemoteEndPoint).Address.ToString();
+            IPEndPoint clientIp = (IPEndPoint)_client.Client.RemoteEndPoint;
+            ClientId = $"{clientIp.Address}:{clientIp.Port}";
         }
 
         /// <summary>

--- a/MtconnectCore.TcpAdapter/TcpConnection.cs
+++ b/MtconnectCore.TcpAdapter/TcpConnection.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Collections;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Policy;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mtconnect
+{
+    public delegate void TcpConnectionConnected(TcpConnection connection);
+    public delegate void TcpConnectionDisconnected(TcpConnection connection);
+    public delegate bool TcpConnectionDataReceived(TcpConnection connection, string message);
+    public class TcpConnection : IDisposable
+    {
+        private bool _disposing { get; set; } = false;
+
+        /// <summary>
+        /// An event that fires when the underlying client stream is opened and connected.
+        /// </summary>
+        public event TcpConnectionConnected OnConnected;
+
+        /// <summary>
+        /// An event that fires when the underlying client stream is closed and disconnected.
+        /// </summary>
+        public event TcpConnectionDisconnected OnDisconnected;
+
+        /// <summary>
+        /// An event that fires when data is fully parsed from the underlying client stream. Note that a new line is used to determine the end of a full message.
+        /// </summary>
+        public event TcpConnectionDataReceived OnDataReceived;
+
+        /// <summary>
+        /// Maximum amount of binary data to receive at a time.
+        /// </summary>
+        private const int BUFFER_SIZE = 4096;
+
+        public ASCIIEncoding Encoder { get; set; } = new ASCIIEncoding();
+
+        /// <summary>
+        /// Reference to the <see cref="TcpClient"/> address.
+        /// </summary>
+        public string ClientId { get; private set; }
+
+        /// <summary>
+        /// The period of time (in milliseconds) to timeout stream reading.
+        /// </summary>
+        public int Heartbeat { get; set; }
+
+        /// <summary>
+        /// Reference to the connection to the <see cref="TcpClient"/>.
+        /// </summary>
+        private TcpClient _client { get; set; }
+
+        /// <summary>
+        /// Reference to the underlying client stream. Note, only available between <see cref="Connect"/> and <see cref="Disconnect"/> calls.
+        /// </summary>
+        private NetworkStream _stream { get; set; }
+
+        public TcpConnection(TcpClient client, int heartbeat = 1000)
+        {
+            _client = client;
+            Heartbeat = heartbeat;
+            ClientId = ((IPEndPoint)_client.Client.RemoteEndPoint).Address.ToString();
+        }
+
+        /// <summary>
+        /// Connects the underlying client stream and begins receiving data.
+        /// </summary>
+        public void Connect()
+        {
+            if (_stream != null) Disconnect();
+
+            _stream = _client.GetStream();
+            Task.Run(() => receive());
+
+            if (OnConnected != null) OnConnected(this);
+        }
+
+        /// <summary>
+        /// Disconnects the underlying client stream and disposes of it. Note that this leaves the connection to the TCP client alone.
+        /// </summary>
+        public void Disconnect()
+        {
+            if (_stream == null) return;
+            _stream?.Close();
+            _stream?.Dispose();
+            _stream = null;
+
+            if (!_disposing && OnDisconnected != null) OnDisconnected(this);
+        }
+
+        /// <summary>
+        /// Writes a message to the underlying client stream.
+        /// </summary>
+        /// <param name="message">Message to send.</param>
+        public void Write(string message) => Write(Encoder.GetBytes(message));
+        /// <summary>
+        /// Writes a binary message to the underlying client stream.
+        /// </summary>
+        /// <param name="message">Message to send.</param>
+        public void Write(byte[] message)
+        {
+            try
+            {
+                _stream?.Write(message, 0, message.Length);
+            }
+            catch (Exception ex)
+            {
+                Disconnect();
+            }
+        }
+
+        /// <summary>
+        /// Flushes the underlying client stream.
+        /// </summary>
+        public void Flush()
+        {
+            _stream?.Flush();
+        }
+
+        /// <summary>
+        /// Continuously reads messages from the underlying client stream.
+        /// </summary>
+        private void receive()
+        {
+            bool heartbeatActive = false;
+
+            byte[] message = new byte[BUFFER_SIZE];
+            int length = 0;
+
+            ArrayList readList = new ArrayList();
+
+            while (_client.Connected)
+            {
+                if (!_stream.DataAvailable) continue;
+
+                int bytesRead = 0;
+
+                readList.Clear();
+                readList.Add(_client.Client);
+                if (Heartbeat > 0 && heartbeatActive)
+                    Socket.Select(readList, null, null, (int)(Heartbeat * 2000));
+                if (readList.Count == 0 && heartbeatActive)
+                {
+                    //_logger?.LogWarning("Heartbeat timed out, closing connection");
+                    break;
+                }
+                bytesRead = _stream.Read(message, length, BUFFER_SIZE - length);
+
+                // See if we have a line
+                int pos = length;
+                length += bytesRead;
+                int eol = 0;
+                for (int i = pos; i < length; i++)
+                {
+                    if (message[i] == '\n')
+                    {
+
+                        String line = Encoder.GetString(message, eol, i);
+
+                        if (OnDataReceived != null)
+                            heartbeatActive = OnDataReceived(this, line);
+
+                        eol = i + 1;
+                    }
+                }
+
+                // Remove the lines that have been processed.
+                if (eol > 0)
+                {
+                    length = length - eol;
+                    // Shift the message array to remove the lines.
+                    if (length > 0)
+                        Array.Copy(message, eol, message, 0, length);
+                }
+            }
+
+            Disconnect();
+        }
+
+        public void Dispose()
+        {
+            _disposing = true;
+            _client?.Dispose();
+            Disconnect();
+            _disposing = false;
+        }
+    }
+}

--- a/SampleAdapter/App.config
+++ b/SampleAdapter/App.config
@@ -4,7 +4,8 @@
 		<section name="adapter" type="System.Configuration.DictionarySectionHandler" />
 	</configSections>
 	<adapter>
-		<!--<add key="heartbeat" value="10000" />-->
+		<add key="maxConnections" value="10" />
+		<add key="heartbeat" value="10000" />
 		<!--<add key="enqueue" value="false" />-->
 		
 	</adapter>

--- a/SampleAdapter/PCModel.cs
+++ b/SampleAdapter/PCModel.cs
@@ -16,17 +16,7 @@ namespace SampleAdapter
         /// </summary>
         public event DataReceivedHandler? OnDataReceived;
 
-        [Event("avail")]
-        public string? Availability { get; set; }
-
-        [Sample("xPos")]
-        public int? XPosition { get; set; }
-
-        [Sample("yPos")]
-        public int? YPosition { get; set; }
-
-        [Event("prog")]
-        public string? WindowTitle { get; set; }
+        public PCStatus Model { get; private set; } = new PCStatus();
 
         private System.Timers.Timer Timer = new System.Timers.Timer();
 
@@ -42,18 +32,18 @@ namespace SampleAdapter
 
         private void Timer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
         {
-            Availability = "AVAILABLE";
+            Model.Availability = "AVAILABLE";
 
             Point lpPoint;
             if (WindowHandles.GetCursorPos(out lpPoint))
             {
-                XPosition = lpPoint.X;
-                YPosition = lpPoint.Y;
+                Model.XPosition = lpPoint.X;
+                Model.YPosition = lpPoint.Y;
             }
             else
             {
-                XPosition = null;
-                YPosition = null;
+                Model.XPosition = null;
+                Model.YPosition = null;
             }
 
             try
@@ -61,25 +51,25 @@ namespace SampleAdapter
                 string activeWindowTitle = WindowHandles.GetActiveWindowTitle();
                 if (!string.IsNullOrEmpty(activeWindowTitle))
                 {
-                    WindowTitle = activeWindowTitle;
+                    Model.WindowTitle = activeWindowTitle;
                 }
                 else
                 {
-                    WindowTitle = null;
+                    Model.WindowTitle = null;
                 }
             }
             catch (Exception ex)
             {
-                WindowTitle = null;
+                Model.WindowTitle = null;
             }
 
             if (OnDataReceived != null)
             {
-                OnDataReceived(this, new DataReceivedEventArgs());
+                OnDataReceived(Model, new DataReceivedEventArgs());
             }
         }
 
-        public void Start()
+        public void Start(CancellationToken token = default)
         {
             Timer.Start();
         }
@@ -88,5 +78,19 @@ namespace SampleAdapter
         {
             Timer.Stop();
         }
+    }
+    public class PCStatus : IAdapterDataModel
+    {
+        [Event("avail")]
+        public string? Availability { get; set; }
+
+        [Sample("xPos")]
+        public int? XPosition { get; set; }
+
+        [Sample("yPos")]
+        public int? YPosition { get; set; }
+
+        [Event("prog")]
+        public string? WindowTitle { get; set; }
     }
 }

--- a/SampleAdapter/Program.cs
+++ b/SampleAdapter/Program.cs
@@ -1,5 +1,6 @@
 ﻿// See https://aka.ms/new-console-template for more information
 using ConsoulLibrary;
+using Microsoft.Extensions.Logging;
 using Mtconnect;
 using Mtconnect.AdapterInterface.DataItems;
 using SampleAdapter.PC;
@@ -19,10 +20,15 @@ namespace SampleAdapter
 
         public static void Main(string[] args)
         {
+            ConsoulLibrary.RenderOptions.WriteMode = RenderOptions.WriteModes.SuppressBlacklist;
+            ConsoulLibrary.RenderOptions.BlacklistColors.Add( ConsoleColor.Gray);
+            var loggerFactory = LoggerFactory.Create(o => { o.AddConsoulLogger();o.SetMinimumLevel(LogLevel.Debug); });
+            var logger = loggerFactory.CreateLogger<Adapter>();
+
             var options = new TcpAdapterOptions();
             options.UpdateFromConfig();
 
-            Adapter = new TcpAdapter(options);
+            Adapter = new TcpAdapter(options, logger);
             Adapter.Start(Model);
 
             Consoul.Write("Reporting: AVAILABILITY, Mouse X-Position, Mouse Y-Position, Active Window Title");

--- a/SampleAdapter/Program.cs
+++ b/SampleAdapter/Program.cs
@@ -22,7 +22,7 @@ namespace SampleAdapter
         {
             ConsoulLibrary.RenderOptions.WriteMode = RenderOptions.WriteModes.SuppressBlacklist;
             ConsoulLibrary.RenderOptions.BlacklistColors.Add( ConsoleColor.Gray);
-            var loggerFactory = LoggerFactory.Create(o => { o.AddConsoulLogger();o.SetMinimumLevel(LogLevel.Trace); });
+            var loggerFactory = LoggerFactory.Create(o => { o.AddConsoulLogger();o.SetMinimumLevel(LogLevel.Debug); });
             var logger = loggerFactory.CreateLogger<Adapter>();
 
             var options = new TcpAdapterOptions();

--- a/SampleAdapter/Program.cs
+++ b/SampleAdapter/Program.cs
@@ -22,7 +22,7 @@ namespace SampleAdapter
         {
             ConsoulLibrary.RenderOptions.WriteMode = RenderOptions.WriteModes.SuppressBlacklist;
             ConsoulLibrary.RenderOptions.BlacklistColors.Add( ConsoleColor.Gray);
-            var loggerFactory = LoggerFactory.Create(o => { o.AddConsoulLogger();o.SetMinimumLevel(LogLevel.Debug); });
+            var loggerFactory = LoggerFactory.Create(o => { o.AddConsoulLogger();o.SetMinimumLevel(LogLevel.Trace); });
             var logger = loggerFactory.CreateLogger<Adapter>();
 
             var options = new TcpAdapterOptions();

--- a/SampleAdapter/SampleAdapter.csproj
+++ b/SampleAdapter/SampleAdapter.csproj
@@ -14,7 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Consoul" Version="1.5.14" />
+    <PackageReference Include="Consoul" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Added cancellation token to starting adapters
 - Refactored code that adds DataItems to the Adapter into an extension class
 - Created `IAdapterDataModel` to help differentiate data models from Adapter service classes (see example)
 - Updated signature for `DataReceivedHandler` to send a type of `IAdapterDataModel`
   - The `Adapter` now consumes this type explicitly for tracking DataItems
 - Updated asynchronous programming in TCP adapter to use tasks instead of deprecated Thread programming
 - Updated `TcpAdapter` to manage client connection with custom class `TcpConnection`.