### PR TITLE
Added TcpAdapter endpoints and Descriptions

### DIFF
--- a/AdapterInterface/AdapterExtensions.cs
+++ b/AdapterInterface/AdapterExtensions.cs
@@ -41,7 +41,7 @@ namespace Mtconnect
                 .ToArray();
         }
         private static Dictionary<Type, PropertyInfo[]> _dataItemProperties = new Dictionary<Type, PropertyInfo[]>();
-        private static bool TryAddDataItems(this Adapter adapter, Type dataModelType, string dataItemNamePrefix = "")
+        private static bool TryAddDataItems(this Adapter adapter, Type dataModelType, string dataItemNamePrefix = "", string dataItemDescriptionPrefix = "")
         {
             if (_dataItemProperties.TryGetValue(dataModelType, out PropertyInfo[] dataItemProperties)) return true;
 
@@ -55,26 +55,27 @@ namespace Mtconnect
                 bool dataItemAdded = false;
                 var dataItemAttribute = property.GetCustomAttribute<DataItemAttribute>();
                 string dataItemName = dataItemNamePrefix + dataItemAttribute.Name;
+                string dataItemDescription = dataItemDescriptionPrefix + dataItemAttribute.Description;
 
                 switch (dataItemAttribute)
                 {
                     case DataItemPartialAttribute _:
-                        dataItemAdded = adapter.TryAddDataItems(property.PropertyType, dataItemName);
+                        dataItemAdded = adapter.TryAddDataItems(property.PropertyType, dataItemName, dataItemDescription);
                         break;
                     case EventAttribute _:
-                        dataItemAdded = adapter.TryAddDataItem(new Event(dataItemName));
+                        dataItemAdded = adapter.TryAddDataItem(new Event(dataItemName, dataItemDescription));
                         break;
                     case SampleAttribute _:
-                        dataItemAdded = adapter.TryAddDataItem(new Sample(dataItemName));
+                        dataItemAdded = adapter.TryAddDataItem(new Sample(dataItemName, dataItemDescription));
                         break;
                     case ConditionAttribute _:
-                        dataItemAdded = adapter.TryAddDataItem(new Condition(dataItemName));
+                        dataItemAdded = adapter.TryAddDataItem(new Condition(dataItemName, dataItemDescription));
                         break;
                     case TimeSeriesAttribute _:
-                        dataItemAdded = adapter.TryAddDataItem(new TimeSeries(dataItemName));
+                        dataItemAdded = adapter.TryAddDataItem(new TimeSeries(dataItemName, dataItemDescription));
                         break;
                     case MessageAttribute _:
-                        dataItemAdded = adapter.TryAddDataItem(new Message(dataItemName));
+                        dataItemAdded = adapter.TryAddDataItem(new Message(dataItemName, dataItemDescription));
                         break;
                     default:
                         dataItemAdded = false;

--- a/AdapterInterface/AdapterInterface.csproj
+++ b/AdapterInterface/AdapterInterface.csproj
@@ -21,7 +21,7 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>1.0.8-alpha</Version>
+    <Version>1.0.9-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AdapterInterface/Contracts/Attributes/ConditionAttribute.cs
+++ b/AdapterInterface/Contracts/Attributes/ConditionAttribute.cs
@@ -6,6 +6,6 @@
     public class ConditionAttribute : DataItemAttribute
     {
         /// <inheritdoc />
-        public ConditionAttribute(string name) : base(name) { }
+        public ConditionAttribute(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/Contracts/Attributes/DataItemAttribute.cs
+++ b/AdapterInterface/Contracts/Attributes/DataItemAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Mtconnect.AdapterInterface.DataItems;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -11,17 +12,24 @@ namespace Mtconnect.AdapterInterface.Contracts.Attributes
     public abstract class DataItemAttribute : Attribute
     {
         /// <summary>
-        /// The key for the MTConnect DataItem.
+        /// <inheritdoc cref="DataItem.Name" path="/summary"/>
         /// </summary>
         public string Name { get; }
 
         /// <summary>
+        /// <inheritdoc cref="DataItem.Description" path="/summary"/>
+        /// </summary>
+        public string Description { get; }
+
+        /// <summary>
         /// Constructs a new DataItem attribute.
         /// </summary>
-        /// <param name="name">Key for the MTConnect DataItem.</param>
-        public DataItemAttribute(string name)
+        /// <param name="name"><inheritdoc cref="DataItemAttribute.Name" path="/summary"/></param>
+        /// <param name="description"><inheritdoc cref="DataItemAttribute.Description" path="/summary"/></param>
+        public DataItemAttribute(string name, string description = null)
         {
             Name = name;
+            Description = description;
         }
     }
 }

--- a/AdapterInterface/Contracts/Attributes/DataItemPartialAttribute.cs
+++ b/AdapterInterface/Contracts/Attributes/DataItemPartialAttribute.cs
@@ -5,10 +5,7 @@
     /// </summary>
     public class DataItemPartialAttribute : DataItemAttribute
     {
-        /// <summary>
-        /// Constructs a new 
-        /// </summary>
-        /// <param name="name"></param>
-        public DataItemPartialAttribute(string name) : base(name) { }
+        /// <inheritdoc />
+        public DataItemPartialAttribute(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/Contracts/Attributes/EventAttribute.cs
+++ b/AdapterInterface/Contracts/Attributes/EventAttribute.cs
@@ -6,6 +6,6 @@
     public class EventAttribute : DataItemAttribute
     {
         /// <inheritdoc />
-        public EventAttribute(string name) : base(name) { }
+        public EventAttribute(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/Contracts/Attributes/MessageAttribute.cs
+++ b/AdapterInterface/Contracts/Attributes/MessageAttribute.cs
@@ -6,6 +6,6 @@
     public class MessageAttribute : DataItemAttribute
     {
         /// <inheritdoc />
-        public MessageAttribute(string name) : base(name) { }
+        public MessageAttribute(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/Contracts/Attributes/SampleAttribute.cs
+++ b/AdapterInterface/Contracts/Attributes/SampleAttribute.cs
@@ -6,6 +6,6 @@
     public class SampleAttribute : DataItemAttribute
     {
         /// <inheritdoc />
-        public SampleAttribute(string name) : base(name) { }
+        public SampleAttribute(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/Contracts/Attributes/TimeSeriesAttribute.cs
+++ b/AdapterInterface/Contracts/Attributes/TimeSeriesAttribute.cs
@@ -6,6 +6,6 @@
     public class TimeSeriesAttribute : DataItemAttribute
     {
         /// <inheritdoc />
-        public TimeSeriesAttribute(string name) : base(name) { }
+        public TimeSeriesAttribute(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/DataItems/Condition.Active.cs
+++ b/AdapterInterface/DataItems/Condition.Active.cs
@@ -49,11 +49,12 @@ namespace Mtconnect.AdapterInterface.DataItems
             /// </summary>
             /// <param name="name">The name of the condition, passed from the parent</param>
             /// <param name="level">The condition level</param>
+            /// <param name="description"><inheritdoc cref="DataItem.DataItem(string, string)" path="/param[@name='description']"/></param>
             /// <param name="text">The descriptive text for the condition</param>
             /// <param name="code">The native code of the alarm or warning</param>
             /// <param name="qualifier">A high/low qualifier</param>
             /// <param name="severity">The native severity of the condition</param>
-            public Active(string name, Level level, string text = "", string code = "", string qualifier = "", string severity = "") : base(name)
+            public Active(string name, Level level, string description = null, string text = "", string code = "", string qualifier = "", string severity = "") : base(name, description)
             {
                 Level = level;
                 Text = text;

--- a/AdapterInterface/DataItems/Condition.cs
+++ b/AdapterInterface/DataItems/Condition.cs
@@ -31,9 +31,10 @@ namespace Mtconnect.AdapterInterface.DataItems
         /// <summary>
         /// Create a new condition
         /// </summary>
-        /// <param name="name">The name of the data item</param>
+        /// <param name="name"><inheritdoc cref="DataItem.DataItem(string, string)" path="/param[@name='name']"/></param>
+        /// <param name="description"><inheritdoc cref="DataItem.DataItem(string, string)" path="/param[@name='description']"/></param>
         /// <param name="simple">If this is a simple condition or if it uses mark and sweep</param>
-        public Condition(string name, bool simple = false) : base(name)
+        public Condition(string name, string description = null, bool simple = false) : base(name, description)
         {
             HasNewLine = true;
             IsSimple = simple;

--- a/AdapterInterface/DataItems/DataItem.cs
+++ b/AdapterInterface/DataItems/DataItem.cs
@@ -26,6 +26,11 @@ namespace Mtconnect.AdapterInterface.DataItems
         public string Name { get; internal set; }
 
         /// <summary>
+        /// A description of the DataItem such as a trace of its source or the methodology for a composite data type.
+        /// </summary>
+        public string Description { get; internal set; }
+
+        /// <summary>
         /// Optional device prefix.
         /// </summary>
         public string DevicePrefix = null;
@@ -89,10 +94,12 @@ namespace Mtconnect.AdapterInterface.DataItems
         /// <summary>
         /// Create a new data item
         /// </summary>
-        /// <param name="name">The name of the data item</param>
-        public DataItem(string name)
+        /// <param name="name"><inheritdoc cref="DataItem.Name" path="/summary"/></param>
+        /// <param name="description"><inheritdoc cref="DataItem.Description" path="/summary"/></param>
+        public DataItem(string name, string description = null)
         {
-            this.Name = name;
+            Name = name;
+            Description = description;
         }
 
         /// <summary>

--- a/AdapterInterface/DataItems/Event.cs
+++ b/AdapterInterface/DataItems/Event.cs
@@ -6,6 +6,6 @@
     public class Event : DataItem 
     {
         /// <inheritdoc />
-        public Event(string name) : base(name) { }
+        public Event(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/DataItems/Message.cs
+++ b/AdapterInterface/DataItems/Message.cs
@@ -7,13 +7,14 @@
     public class Message : DataItem
     {
         string mCode;
-        
+
         /// <summary>
         /// Create a new message, set NewLine to true so this comes out 
         /// on a separate line.
         /// </summary>
-        /// <param name="name">The name of the data item</param>
-        public Message(string name) : base(name)
+        /// <param name="name"><inheritdoc cref="DataItem.DataItem(string, string)" path="/param[@name='name']"/></param>
+        /// <param name="description"><inheritdoc cref="DataItem.DataItem(string, string)" path="/param[@name='description']"/></param>
+        public Message(string name, string description = null) : base(name, description)
         {
             HasNewLine = true;
         }

--- a/AdapterInterface/DataItems/Sample.cs
+++ b/AdapterInterface/DataItems/Sample.cs
@@ -6,6 +6,6 @@
     public class Sample : DataItem
     {
         /// <inheritdoc />
-        public Sample(string name) : base(name) { }
+        public Sample(string name, string description = null) : base(name, description) { }
     }
 }

--- a/AdapterInterface/DataItems/TimeSeries.cs
+++ b/AdapterInterface/DataItems/TimeSeries.cs
@@ -29,9 +29,10 @@ namespace Mtconnect.AdapterInterface.DataItems
         /// <summary>
         /// Constructs a new Time Series dataset.
         /// </summary>
-        /// <param name="name"><inheritdoc cref="DataItem.Name" path="/summary"/></param>
+        /// <param name="name"><inheritdoc cref="DataItem.DataItem(string, string)" path="/param[@name='name']"/></param>
+        /// <param name="description"><inheritdoc cref="DataItem.DataItem(string, string)" path="/param[@name='description']"/></param>
         /// <param name="rate"><inheritdoc cref="Rate" path="/summary"/></param>
-        public TimeSeries(string name, double rate = 0.0) : base(name)
+        public TimeSeries(string name, string description = null, double rate = 0.0) : base(name, description)
         {
             HasNewLine = true;
             Rate = rate;

--- a/MtconnectCore.TcpAdapter/TcpAdapter.csproj
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.csproj
@@ -19,7 +19,7 @@
 	  <RepositoryType>git</RepositoryType>
 	  <PackageTags>Mtconnect;Adapter;TCP;TAMS;</PackageTags>
 	  <PackageReleaseNotes>Added extra logging and refined TcpConnections.</PackageReleaseNotes>
-	  <Version>1.0.8-alpha</Version>
+	  <Version>1.0.9-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleAdapter/PCModel.cs
+++ b/SampleAdapter/PCModel.cs
@@ -84,13 +84,13 @@ namespace SampleAdapter
         [Event("avail")]
         public string? Availability { get; set; }
 
-        [Sample("xPos")]
+        [Sample("xPos", "user32.dll#GetCursorPos().X")]
         public int? XPosition { get; set; }
 
-        [Sample("yPos")]
+        [Sample("yPos", "user32.dll#GetCursorPos().Y")]
         public int? YPosition { get; set; }
 
-        [Event("prog")]
+        [Event("prog", "user32.dll#GetWindowText(user32.dll#GetForegroundWindow(), StringBuilder(256), 256)")]
         public string? WindowTitle { get; set; }
     }
 }


### PR DESCRIPTION
 - Added `* DATAITEMS` request to get a pipe-delimited list of DataItem.Names
 - Added `* DATAITEM_DESCRIPTION {DataItem.Name}` request to get the Description of the DataItem requested by name
 - Updated example to show how Description can be utilized to specify the source of the DataItem