### PR TITLE
Added universal Adapter Service

### DIFF
--- a/AdapterInterface/Adapter.cs
+++ b/AdapterInterface/Adapter.cs
@@ -10,10 +10,6 @@ using Mtconnect.AdapterInterface;
 using Mtconnect.AdapterInterface.Assets;
 using System.Data;
 using System.Collections.Concurrent;
-using System.Reflection;
-using Mtconnect.AdapterInterface.Contracts.Attributes;
-using System.Diagnostics.Tracing;
-using EventAttribute = Mtconnect.AdapterInterface.Contracts.Attributes.EventAttribute;
 using System.Threading;
 
 namespace Mtconnect
@@ -356,23 +352,23 @@ namespace Mtconnect
         /// </summary>
         /// <param name="source">Reference to the source of the Adapter.</param>
         /// <param name="begin">Flag for whether or not to also call <see cref="Begin"/>.</param>
-        public void Start<T>(T source, bool begin = true) where T : class, IAdapterSource
-            => Start(new IAdapterSource[] { source }, begin);
+        public void Start<T>(T source, bool begin = true, CancellationToken token = default) where T : class, IAdapterSource
+            => Start(new IAdapterSource[] { source }, begin, token);
 
         /// <summary>
         /// Starts the listener thread and the provided <see cref="IAdapterSource"/>s.
         /// </summary>
         /// <param name="sources">Reference to the sources of the Adapter.</param>
         /// <param name="begin"><inheritdoc cref="Start{T}(T, bool)" path="/param[@name='begin']"/></param>
-        public void Start(IEnumerable<IAdapterSource> sources, bool begin = true)
+        public void Start(IEnumerable<IAdapterSource> sources, bool begin = true, CancellationToken token = default)
         {
-            Start(begin);
+            Start(begin, token);
 
             foreach (var source in sources)
             {
                 _sources.Add(source);
                 source.OnDataReceived += _source_OnDataReceived;
-                source.Start();
+                source.Start(token);
             }
         }
 

--- a/AdapterInterface/AdapterInterface.csproj
+++ b/AdapterInterface/AdapterInterface.csproj
@@ -21,7 +21,7 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>1.0.9-alpha</Version>
+    <Version>1.0.10-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MtconnectCore.TcpAdapter/TcpAdapter.csproj
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.csproj
@@ -19,7 +19,7 @@
 	  <RepositoryType>git</RepositoryType>
 	  <PackageTags>Mtconnect;Adapter;TCP;TAMS;</PackageTags>
 	  <PackageReleaseNotes>Added extra logging and refined TcpConnections.</PackageReleaseNotes>
-	  <Version>1.0.9-alpha</Version>
+	  <Version>1.0.10-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Service/Configuration/AdapterConfiguration.cs
+++ b/Service/Configuration/AdapterConfiguration.cs
@@ -1,0 +1,24 @@
+﻿
+namespace Service.Configuration
+{
+    /// <summary>
+    /// Options for configuring a single <see cref="Mtconnect.Adapter"/>.
+    /// </summary>
+    public class AdapterConfiguration
+    {
+        /// <summary>
+        /// Filename for the <see cref="Mtconnect.Adapter"/> implementation.
+        /// </summary>
+        public string Adapter { get; set; }
+
+        /// <summary>
+        /// Filename(s) for the <see cref="Mtconnect.IAdapterSource"/>(s) to attach to the referenced <see cref="Mtconnect.Adapter"/>.
+        /// </summary>
+        public string[] Sources { get; set; }
+
+        /// <summary>
+        /// ServiceConfiguration options for the referenced <see cref="Mtconnect.Adapter"/>.
+        /// </summary>
+        public Dictionary<string, object>? Options { get; set; }
+    }
+}

--- a/Service/Configuration/ServiceConfiguration.cs
+++ b/Service/Configuration/ServiceConfiguration.cs
@@ -1,0 +1,18 @@
+﻿
+namespace Service.Configuration
+{
+    public class ServiceConfiguration
+    {
+        /// <summary>
+        /// Collection of simultaneous adapter configurations.
+        /// </summary>
+        public AdapterConfiguration[] Adapters { get; set; }
+
+        public SourceConfiguration[] Sources { get; set; }
+
+        /// <summary>
+        /// Collection of additional DLLs to load
+        /// </summary>
+        public string[] Imports { get; set; }
+    }
+}

--- a/Service/Configuration/SourceConfiguration.cs
+++ b/Service/Configuration/SourceConfiguration.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Service.Configuration
+{
+    public class SourceConfiguration
+    {
+        public string Source { get; set; }
+
+        public Dictionary<string, object>? Options { get; set; }
+    }
+}

--- a/Service/Program.cs
+++ b/Service/Program.cs
@@ -1,0 +1,17 @@
+using Service;
+using Service.Configuration;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices((hostContext, services) =>
+    {
+        IConfiguration configuration = hostContext.Configuration;
+
+        ServiceConfiguration? config = configuration.GetSection("Service").Get<ServiceConfiguration>();
+
+        services.AddSingleton(config);
+
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+host.Run();

--- a/Service/Properties/launchSettings.json
+++ b/Service/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+﻿{
+  "profiles": {
+    "Service": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Service/Service.csproj
+++ b/Service/Service.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-Service-61541f77-58dd-4dc3-87ce-1d191923733d</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AdapterInterface\AdapterInterface.csproj" />
+  </ItemGroup>
+</Project>

--- a/Service/Worker.cs
+++ b/Service/Worker.cs
@@ -1,0 +1,244 @@
+using Mtconnect;
+using Mtconnect.AdapterInterface;
+using Service.Configuration;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Service
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _workerLogger;
+        private readonly ILogger<Adapter> _adapterLogger;
+        private ServiceConfiguration _config;
+        private List<Assembly> _dlls = new List<Assembly>();
+        private Dictionary<Adapter, List<IAdapterSource>> _adapters { get; set; }
+            = new Dictionary<Adapter, List<IAdapterSource>>();
+
+        public Worker(ILogger<Worker> workerLogger,ILogger<Adapter> adapterLogger, ServiceConfiguration config)
+        {
+            _workerLogger = workerLogger;
+            _adapterLogger = adapterLogger;
+            _config = config;
+
+            _initialize();
+        }
+        private void _initialize()
+        {
+            _adapters = new Dictionary<Adapter, List<IAdapterSource>>();
+
+            _importDlls();
+
+            foreach (var dll in _dlls)
+            {
+                var adapterTypes = dll.GetTypes().Where(o => !o.IsInterface && !o.IsAbstract && o.IsSubclassOf(typeof(Adapter)));
+
+                foreach (var adapterType in adapterTypes)
+                {
+                    var adapterConfig = _config.Adapters.FirstOrDefault(o => o.Adapter == adapterType.Name || o.Adapter == adapterType.FullName);
+                    if (adapterConfig == null)
+                    {
+                        _workerLogger?.LogWarning("Could not find configuration for Adapter implementation {AdapterType}", adapterType.FullName);
+                        continue;
+                    }
+
+                    //AdapterOptions result, ILogger<Adapter> workerLogger = null
+                    var adapterCtors = adapterType.GetConstructors();
+                    foreach (var adapterCtor in adapterCtors)
+                    {
+                        var optionsParam = adapterCtor.GetParameters().FirstOrDefault(o => o.ParameterType.IsSubclassOf(typeof(AdapterOptions)));
+                        object? options = _constructFromConfig(adapterConfig.Options, optionsParam?.ParameterType);
+
+                        var adapter = adapterCtor.Invoke(new object?[] { options, _adapterLogger }) as Adapter;
+                        if (adapter == null)
+                        {
+                            _workerLogger?.LogError(new InvalidCastException("Failed to construct Adapter"), "Failed to construct Adapter { AdapterType }", adapterType.FullName);
+                            continue;
+                        }
+                        if (!_adapters.TryAdd(adapter, new List<IAdapterSource>()))
+                        {
+                            _workerLogger?.LogError(new ArgumentNullException(), "Failed to add Adapter { AdapterType }, likely already added", adapterType.FullName);
+                            continue;
+                        }
+                    }
+                }
+            }
+
+            foreach (var dll in _dlls)
+            {
+                var sourceTypes = dll.GetTypes().Where(o => typeof(IAdapterSource).IsAssignableFrom(o) && !o.IsInterface && !o.IsAbstract);
+
+                foreach (var sourceType in sourceTypes)
+                {
+                    var sourceConfig = _config.Sources?.FirstOrDefault(o => o.Source == sourceType.Name || o.Source == sourceType.FullName);
+                    IAdapterSource? source = _constructFromConfig(sourceConfig?.Options, sourceType) as IAdapterSource;
+                    if (source == null)
+                    {
+                        _workerLogger?.LogError(new InvalidCastException("Failed to construct IAdapterSource"), "Failed to construct IAdapterSource { SourceType }", sourceType.FullName);
+                        continue;
+                    }
+
+                    var adapterConfigs = _config.Adapters.Where(o => o.Sources.Contains(sourceType.Name) || o.Sources.Contains(sourceType.FullName));
+
+                    foreach (var adapterConfig in adapterConfigs)
+                    {
+                        var adapter = _adapters
+                            .Keys
+                            .FirstOrDefault(o => o.GetType().Name == adapterConfig.Adapter || o.GetType().FullName == adapterConfig.Adapter);
+                        if (adapter == null)
+                        {
+                            _workerLogger?.LogError("Could not find adapter for IAdapterSource according to configuration");
+                            continue;
+                        }
+
+                        _adapters[adapter].Add(source);
+                    }
+                }
+            }
+        }
+        private object? _constructFromConfig(object? config, Type targetType)
+        {
+            Type? configType = config?.GetType();
+            bool isDictionary = config is IDictionary<string, object?>;
+
+            object? result = null;
+            var ctors = targetType.GetConstructors().OrderByDescending(o => o.GetParameters()?.Length);
+            foreach (var ctor in ctors)
+            {
+                var ctorParams = ctor.GetParameters();
+
+                List<object?> resultParams = new List<object?>();
+                foreach (var ctorParam in ctorParams)
+                {
+                    object? value = null;
+                    if (isDictionary)
+                    {
+                        if ((config as IDictionary).Contains(ctorParam.Name))
+                        {
+                            value = (config as IDictionary)[ctorParam.Name];
+                        }
+                    } else
+                    {
+                        var property = configType?.GetProperty(ctorParam.Name);
+                        if (property != null)
+                        {
+                            value = property.GetValue(config, null);
+                        }
+                    }
+
+                    if (value != null)
+                    {
+                        value = Convert.ChangeType(value, ctorParam.ParameterType);
+
+                        resultParams.Add(value);
+                    } else if (ctorParam.IsOptional)
+                    {
+                        resultParams.Add(ctorParam.DefaultValue);
+                    }
+                }
+                if (resultParams.Count == ctorParams.Length)
+                {
+                    result = ctor.Invoke(resultParams.ToArray());
+                    if (result != null) break;
+                }
+            }
+
+            if (result == null)
+            {
+                _workerLogger?.LogError("Could not construct {AdapterOptionsType}", targetType.FullName);
+                return null;
+            }
+
+            Dictionary<string, object?>? configProperties = null;
+            if (isDictionary)
+            {
+                configProperties = (config as Dictionary<string, object?>);
+            }
+            else
+            {
+                configProperties = configType?.GetProperties().ToDictionary(o => o.Name, o => o.GetValue(config, null));
+            }
+            if (configProperties != null)
+            {
+                foreach (var kvp in configProperties)
+                {
+                    var property = targetType.GetProperty(kvp.Key);
+                    if (property == null) continue;
+
+                    property.SetValue(result, kvp.Value);
+                }
+            }
+
+            return result;
+        }
+        private void _importDlls()
+        {
+            foreach (var importDll in _config.Imports)
+            {
+                var dllFilename = Path.Combine(Directory.GetParent(Environment.ProcessPath).FullName, importDll);
+                if (!File.Exists(dllFilename))
+                {
+                    _workerLogger?.LogError(new DllNotFoundException("Could not find Adapter DLL"), "Could not find Adapter DLL { AdapterFilename }", dllFilename);
+                    continue;
+                }
+
+                var dll = Assembly.Load(File.ReadAllBytes(dllFilename));
+                if (dll == null)
+                {
+                    _workerLogger?.LogError(new FileLoadException("Failed to load Adapter DLL", dllFilename), "Failed to load Adapter DLL { AdapterFilename }", dllFilename);
+                    continue;
+                }
+                _dlls.Add(dll);
+            }
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _workerLogger.LogInformation("Worker running at: {time}", DateTimeOffset.Now);
+
+            if (!_dlls.Any())
+            {
+                _workerLogger?.LogError("Missing Imports in configuration", _config);
+                return;
+            }
+
+            if (!_adapters.Any())
+            {
+                _workerLogger?.LogError("Missing Adapters in configuration", _config);
+                return;
+            }
+
+            if (!_adapters.SelectMany(o => o.Value).Any())
+            {
+                _workerLogger?.LogError("Missing IAdapterSources in configuration", _config);
+                return;
+            }
+
+            _start(stoppingToken);
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(1000, stoppingToken);
+            }
+
+            _stop();
+        }
+
+        private void _start(CancellationToken token)
+        {
+            foreach (var adapterKvp in _adapters)
+            {
+                adapterKvp.Key.Start(adapterKvp.Value, token: token);
+                _workerLogger?.LogInformation("Started Adapter {AdapterType}", adapterKvp.Key.GetType().FullName);
+            }
+        }
+        private void _stop()
+        {
+            foreach (var adapterKvp in _adapters)
+            {
+                adapterKvp.Key.Stop();
+            }
+        }
+    }
+}

--- a/Service/appsettings.Development.json
+++ b/Service/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/Service/appsettings.json
+++ b/Service/appsettings.json
@@ -20,6 +20,14 @@
           "maxConnections": 2
         }
       }
+    ],
+    "Sources": [
+      {
+        "Source": "SampleAdapter.PCStatusMonitor",
+        "Options": {
+          "sampleRate": 1000
+        }
+      }
     ]
   }
 }

--- a/Service/appsettings.json
+++ b/Service/appsettings.json
@@ -1,0 +1,25 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "Service": {
+    "Imports": [
+      "PCAdapter.dll",
+      "Mtconnect.TcpAdapter.dll"
+    ],
+    "Adapters": [
+      {
+        "Adapter": "Mtconnect.TcpAdapter",
+        "Sources": [ "SampleAdapter.PCStatusMonitor" ],
+        "Options": {
+          "heartbeat": 10000,
+          "port": 7878,
+          "maxConnections": 2
+        }
+      }
+    ]
+  }
+}

--- a/TAMSAdapter.sln
+++ b/TAMSAdapter.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdapterInterface", "Adapter
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TcpAdapter", "MtconnectCore.TcpAdapter\TcpAdapter.csproj", "{78B76C63-5060-48E6-95B5-53C8E226C1F2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Service", "Service\Service.csproj", "{C29B2264-84F9-4DF0-9E29-36F2F6A5E96D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +37,10 @@ Global
 		{78B76C63-5060-48E6-95B5-53C8E226C1F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{78B76C63-5060-48E6-95B5-53C8E226C1F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{78B76C63-5060-48E6-95B5-53C8E226C1F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C29B2264-84F9-4DF0-9E29-36F2F6A5E96D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C29B2264-84F9-4DF0-9E29-36F2F6A5E96D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C29B2264-84F9-4DF0-9E29-36F2F6A5E96D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C29B2264-84F9-4DF0-9E29-36F2F6A5E96D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
 - Minor bug fix with `_activeClients` in `TcpAdapter`
 - Minor bug fix with missing `CancellationToken` in `Start` methods of `Adapter`
 - Added a .NET Core Worker Service project as a universal MTConnect Adapter service

## Universal MTConnect Adapter Service
This .NET Core Worker Service is intended to provide plug-and-play support for deploying MTConnect Adapters.

With an updated libraries containing both `Adapter` and `IAdapterSource` implementations, simply copy the `.dll` files into the directory with the executable. Then, configure the `appsettings.json` based on the constructors of the aforementioned implementations. For example, add a `Service` key in your `appsettings.json`:

```json
{
  // ... whatever other settings like Logging
  "Service": {
    "Imports": [
      "PCAdapter.dll", // See SampleAdapter.csproj
      "Mtconnect.TcpAdapter.dll" // See TcpAdapter.csproj
    ],
    "Adapters": [
      {
        "Adapter": "Mtconnect.TcpAdapter", // Reference the Type for the Adapter implementation
        "Sources": [ "SampleAdapter.PCStatusMonitor" ], // Reference the Type(s) for the IAdapterSource implementation you want this Adapter to output
        // These options pertain only to the Adapter implementation, so these are specific to TcpAdapter
        "Options": {
          "heartbeat": 10000,
          "port": 7878,
          "maxConnections": 2
        }
      }
    ],
  // As needed, provide IAdapterSource configurations,
    "Sources": [
      {
        "Source": "SampleAdapter.PCStatusMonitor",
        // These options pertain only to the IAdapterSource implementation, so these are specific to PCStatusMonitor
        "Options": {
          "sampleRate": 1000 // normally 50ms
        }
      }
    ]
  }
}
```