### PR TITLE
Fixed unavailable/null error with DataItems

### DIFF
--- a/AdapterInterface/AdapterInterface.csproj
+++ b/AdapterInterface/AdapterInterface.csproj
@@ -21,7 +21,7 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>1.0.11-alpha</Version>
+    <Version>1.0.12-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AdapterInterface/DataItems/DataItem.cs
+++ b/AdapterInterface/DataItems/DataItem.cs
@@ -49,7 +49,10 @@ namespace Mtconnect.AdapterInterface.DataItems
                 var updatedValue = value;
                 if (FormatValue != null) updatedValue = FormatValue(updatedValue);
 
-                if (_value?.Equals(updatedValue) == false)
+                if (_isReadyToUpdate(updatedValue)
+                    && ((_value == null && updatedValue != null)
+                    || (_value != null && updatedValue == null)
+                    || _value?.Equals(updatedValue) == false))
                 {
                     var now = DateTime.UtcNow;
                     var e = new DataItemChangedEventArgs(_value, updatedValue, LastChanged, now);
@@ -67,6 +70,11 @@ namespace Mtconnect.AdapterInterface.DataItems
             }
             get { return _value; }
         }
+
+        private bool _isReadyToUpdate(object value)
+            => _value?.Equals(Constants.UNAVAILABLE) == true
+            ? (value is string ? !string.IsNullOrEmpty(value as string) : value != null)
+            : value != null;
 
         /// <summary>
         /// Timestamp of when the <see cref="Value"/> was last Changed.

--- a/Constants.cs
+++ b/Constants.cs
@@ -1,6 +1,4 @@
 ﻿
-using System;
-
 namespace Mtconnect.AdapterInterface
 {
     internal static class Constants
@@ -8,11 +6,11 @@ namespace Mtconnect.AdapterInterface
         /// <summary>
         /// The standard, indeterminate state for MTConnect.
         /// </summary>
-        public const string UNAVAILABLE = "UNAVAILABLE";
+        internal const string UNAVAILABLE = "UNAVAILABLE";
 
         /// <summary>
         /// The W3C ISO 8601 format for timestamps.
         /// </summary>
-        public const string DATE_TIME_FORMAT = "yyyy-MM-dd\\THH:mm:ss.fffffffK";
+        internal const string DATE_TIME_FORMAT = "yyyy-MM-dd\\THH:mm:ss.fffffffK";
     }
 }

--- a/MtconnectCore.TcpAdapter/TcpAdapter.csproj
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.csproj
@@ -19,7 +19,7 @@
 	  <RepositoryType>git</RepositoryType>
 	  <PackageTags>Mtconnect;Adapter;TCP;TAMS;</PackageTags>
 	  <PackageReleaseNotes>Added extra logging and refined TcpConnections.</PackageReleaseNotes>
-	  <Version>1.0.10-alpha</Version>
+	  <Version>1.0.11-alpha</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleAdapter/PCModel.cs
+++ b/SampleAdapter/PCModel.cs
@@ -20,6 +20,8 @@ namespace SampleAdapter
 
         private System.Timers.Timer Timer = new System.Timers.Timer();
 
+        private long _loopCount { get; set; } = 0;
+
         /// <summary>
         /// Constructs a new instance of the PC monitor.
         /// </summary>
@@ -63,10 +65,17 @@ namespace SampleAdapter
                 Model.WindowTitle = null;
             }
 
+            // Comment out for testing * DATAITEM_VALUE foobar
+            if (_loopCount > 5000 / Timer.Interval)
+            {
+                Model.FooBar = "foobar";
+            }
+
             if (OnDataReceived != null)
             {
                 OnDataReceived(Model, new DataReceivedEventArgs());
             }
+            _loopCount++;
         }
 
         public void Start(CancellationToken token = default)
@@ -92,5 +101,8 @@ namespace SampleAdapter
 
         [Event("prog", "user32.dll#GetWindowText(user32.dll#GetForegroundWindow(), StringBuilder(256), 256)")]
         public string? WindowTitle { get; set; }
+
+        [Event("foobar")]
+        public string? FooBar { get; set; } = null;
     }
 }


### PR DESCRIPTION
Fixed an issue where `IAdapterDataModel` properties that were not set or initialized as null/empty were never updated in the adapter.

 - Added a few more tracing logs
 - Added command in `TcpAdapter` `* DATAITEM_VALUE {DataItemName}` to retrieve the current value for a registered data item. It returns the timestamp the DataItem was last changed (or "never"), the DataItem name, and its currently registered value.