### PR TITLE
Compatibility updates for Service

### DIFF
--- a/AdapterInterface/Adapter.cs
+++ b/AdapterInterface/Adapter.cs
@@ -366,11 +366,17 @@ namespace Mtconnect
             foreach (var source in sources)
             {
                 _sources.Add(source);
+                source.OnAdapterSourceStarted += Source_OnAdapterSourceStarted;
                 source.OnAdapterSourceStopped += Source_OnAdapterSourceStopped;
                 source.OnDataReceived += _source_OnDataReceived;
                 source.Start(token);
             }
             TriggerOnStartedEvent();
+        }
+
+        private void Source_OnAdapterSourceStarted(IAdapterSource sender, AdapterSourceStartedEventArgs e)
+        {
+            _logger?.LogInformation("Adapter's Source {AdapterSourceType} has started", sender.GetType().FullName);
         }
 
         private void Source_OnAdapterSourceStopped(IAdapterSource sender, AdapterSourceStoppedEventArgs e)
@@ -417,6 +423,7 @@ namespace Mtconnect
             foreach (var source in _sources)
             {
                 source.Stop();
+                source.OnAdapterSourceStarted -= Source_OnAdapterSourceStarted;
                 source.OnAdapterSourceStopped -= Source_OnAdapterSourceStopped;
                 source.OnDataReceived -= _source_OnDataReceived;
             }

--- a/AdapterInterface/AdapterInterface.csproj
+++ b/AdapterInterface/AdapterInterface.csproj
@@ -21,7 +21,7 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>1.0.15</Version>
+    <Version>1.0.16</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MtconnectCore.TcpAdapter/TcpAdapter.cs
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.cs
@@ -93,11 +93,11 @@ namespace Mtconnect
         /// <inheritdoc />
         public override void Stop(Exception ex = null)
         {
-            base.Stop();
+            base.Stop(ex);
 
             if (State > AdapterStates.NotStarted)
             {
-                _logger?.LogInformation("Stopping Adapter");
+                _logger?.LogInformation("Stopping TcpAdapter");
                 State = AdapterStates.Stopping;
 
                 // Queue the _listerThread to cancel

--- a/MtconnectCore.TcpAdapter/TcpAdapter.csproj
+++ b/MtconnectCore.TcpAdapter/TcpAdapter.csproj
@@ -19,7 +19,7 @@
 	  <RepositoryType>git</RepositoryType>
 	  <PackageTags>Mtconnect;Adapter;TCP;TAMS;</PackageTags>
 	  <PackageReleaseNotes>Added extra logging and refined TcpConnections.</PackageReleaseNotes>
-	  <Version>1.0.15</Version>
+	  <Version>1.0.16</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Service/AdapterFactory.cs
+++ b/Service/AdapterFactory.cs
@@ -90,8 +90,23 @@ namespace Service
                     _logger?.LogWarning(ex, ex.Message + " in Adapter type '{AdapterType}'", adapterType.FullName);
                     continue;
                 }
+                adapterInstance.Instance.OnStopped += Instance_OnStopped;
                 adapterInstance.Instance.Start(adapterInstance.Sources, token: token);
                 _logger?.LogInformation("Started Adapter {AdapterType}", adapterType.FullName);
+            }
+        }
+
+        private void Instance_OnStopped(Adapter sender, AdapterStoppedEventArgs e)
+        {
+            if (e.Exception != null)
+            {
+                _logger?.LogError(e.Exception, "Adapter Instance stopped due to error");
+            } else if (e.WasCancelled)
+            {
+                _logger?.LogWarning("Adapter Instance was cancelled");
+            } else
+            {
+                _logger?.LogInformation("Adapter Instance stopped");
             }
         }
 
@@ -118,6 +133,7 @@ namespace Service
                 }
 
                 adapterInstance.Instance.Stop();
+                adapterInstance.Instance.OnStopped -= Instance_OnStopped;
             }
         }
 

--- a/Service/Service.csproj
+++ b/Service/Service.csproj
@@ -8,8 +8,6 @@
 	<OutputType>exe</OutputType>
 	<PublishSingleFile Condition="'$(Configuration)' == 'Release'">true</PublishSingleFile>
 	<PublishReadyToRun Condition="'$(Configuration)' == 'Release'">true</PublishReadyToRun>
-	<RuntimeIdentifier>win-x86</RuntimeIdentifier>
-	<PlatformTarget>x86</PlatformTarget>
 	<Version>1.0.0.1</Version>
   </PropertyGroup>
 

--- a/Service/Worker.cs
+++ b/Service/Worker.cs
@@ -42,7 +42,7 @@ namespace Service
                     continue;
                 }
 
-                var dll = Assembly.Load(File.ReadAllBytes(dllFilename));
+                var dll = Assembly.UnsafeLoadFrom(dllFilename);
                 if (dll == null)
                 {
                     _workerLogger?.LogError(new FileLoadException("Failed to load Adapter DLL", dllFilename), "Failed to load Adapter DLL {AdapterFilename}", dllFilename);


### PR DESCRIPTION
Tested universal Service with a complex implementation of `IAdapterSource` that required many supplementary libraries and made updates based on that real-world implementation.

 - Added listener to `IAdapterSource.OnAdapterSourceStarted` within the `Adapter` when the `Adapter` starts
 - Removed listener to `IAdapterSource.OnAdapterSourceStarted` within the `Adapter` when the `IAdapterSource` stops
 - Fixed bug with `TcpAdapter` not bubbling-up `OnStop` exceptions
 - Updated Service worker to listen to `Adapter.OnStopped` event
 - Removed scope of Service to x86 platform
 - Converted Assembly load to `UnsafeLoadFrom` just because it worked. Discussions are definitely welcome on this change.