### PR TITLE
Tbm0115/dictionary handling

### DIFF
--- a/AdapterSdk/AdapterSdk.csproj
+++ b/AdapterSdk/AdapterSdk.csproj
@@ -21,7 +21,7 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>2.0.2</Version>
+    <Version>2.0.3-alpha-1</Version>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<DebugSymbols>true</DebugSymbols>

--- a/AdapterSdk/AdapterSdk.csproj
+++ b/AdapterSdk/AdapterSdk.csproj
@@ -21,7 +21,7 @@
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>2.0.3-alpha-1</Version>
+    <Version>2.0.3</Version>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<DebugSymbols>true</DebugSymbols>

--- a/AdapterSdk/AdapterSdk.xml
+++ b/AdapterSdk/AdapterSdk.xml
@@ -25826,6 +25826,9 @@
         <member name="M:Mtconnect.AdapterSdk.DataItems.Condition.Active.Validate(Mtconnect.AdapterSdk.Contracts.ValidationResult@)">
             <inheritdoc />
         </member>
+        <member name="M:Mtconnect.AdapterSdk.DataItems.Condition.Active.Copy">
+            <inheritdoc />
+        </member>
         <member name="P:Mtconnect.AdapterSdk.DataItems.Condition.Category">
             <inheritdoc />
         </member>
@@ -25908,6 +25911,9 @@
             <returns>A list of activations (also DataItems)</returns>
         </member>
         <member name="M:Mtconnect.AdapterSdk.DataItems.Condition.Validate(Mtconnect.AdapterSdk.Contracts.ValidationResult@)">
+            <inheritdoc />
+        </member>
+        <member name="M:Mtconnect.AdapterSdk.DataItems.Condition.Copy">
             <inheritdoc />
         </member>
         <member name="T:Mtconnect.AdapterSdk.DataItems.Condition.Level">
@@ -26145,6 +26151,13 @@
         <member name="M:Mtconnect.AdapterSdk.DataItems.DataItem.GetHashCode">
             <inheritdoc />
         </member>
+        <member name="M:Mtconnect.AdapterSdk.DataItems.DataItem.Copy">
+            <summary>
+            Copies the current DataItem into a new object.
+            </summary>
+            <typeparam name="T"></typeparam>
+            <returns></returns>
+        </member>
         <member name="T:Mtconnect.AdapterSdk.DataItems.Event">
             <summary>
             Event is just an alias for DataItem
@@ -26163,6 +26176,9 @@
             <param name="subType"><inheritdoc cref="M:Mtconnect.AdapterSdk.DataItems.DataItem.#ctor(System.String,System.String,System.String,System.String)" path="/param[@name='subType']"/></param>
         </member>
         <member name="M:Mtconnect.AdapterSdk.DataItems.Event.Validate(Mtconnect.AdapterSdk.Contracts.ValidationResult@)">
+            <inheritdoc />
+        </member>
+        <member name="M:Mtconnect.AdapterSdk.DataItems.Event.Copy">
             <inheritdoc />
         </member>
         <member name="T:Mtconnect.AdapterSdk.DataItems.Message">
@@ -26195,6 +26211,9 @@
             <returns>A text representation</returns>
         </member>
         <member name="M:Mtconnect.AdapterSdk.DataItems.Message.Validate(Mtconnect.AdapterSdk.Contracts.ValidationResult@)">
+            <inheritdoc />
+        </member>
+        <member name="M:Mtconnect.AdapterSdk.DataItems.Message.Copy">
             <inheritdoc />
         </member>
         <member name="T:Mtconnect.AdapterSdk.DataItems.ReportedValue">
@@ -26248,6 +26267,9 @@
         <member name="M:Mtconnect.AdapterSdk.DataItems.Sample.Validate(Mtconnect.AdapterSdk.Contracts.ValidationResult@)">
             <inheritdoc />
         </member>
+        <member name="M:Mtconnect.AdapterSdk.DataItems.Sample.Copy">
+            <inheritdoc />
+        </member>
         <member name="T:Mtconnect.AdapterSdk.DataItems.TimeSeries">
             <summary>
             Represents data that is collected at a high rate.
@@ -26283,6 +26305,9 @@
             <returns>A text representation</returns>
         </member>
         <member name="M:Mtconnect.AdapterSdk.DataItems.TimeSeries.Validate(Mtconnect.AdapterSdk.Contracts.ValidationResult@)">
+            <inheritdoc />
+        </member>
+        <member name="M:Mtconnect.AdapterSdk.DataItems.TimeSeries.Copy">
             <inheritdoc />
         </member>
         <member name="T:Mtconnect.AdapterSdk.Units.MtconnectUnit">

--- a/AdapterSdk/DataItems/Condition.Active.cs
+++ b/AdapterSdk/DataItems/Condition.Active.cs
@@ -124,6 +124,18 @@ namespace Mtconnect.AdapterSdk.DataItems
                 // TODO: Determine what needs to be validated from the Adapter
                 return true;
             }
+
+            /// <inheritdoc />
+            public override DataItem Copy()
+            {
+                var copy = new Active(this.Name, this.Level, this.Description, this.Text, this.NativeCode, this.Qualifier, this.NativeSeverity);
+                copy.FormatValue = this.FormatValue;
+                copy.ModelPath = this.ModelPath;
+                copy.Units = this.Units;
+                copy.HasTimestampOverride = this.HasTimestampOverride;
+
+                return copy;
+            }
         }
     }
 }

--- a/AdapterSdk/DataItems/Condition.cs
+++ b/AdapterSdk/DataItems/Condition.cs
@@ -283,5 +283,17 @@ namespace Mtconnect.AdapterSdk.DataItems
             };
             return true;
         }
+
+        /// <inheritdoc />
+        public override DataItem Copy()
+        {
+            var copy = new Condition(this.Name, this.ObservationalType, this.ObservationalSubType, this.Description, this.IsSimple);
+            copy.FormatValue = this.FormatValue;
+            copy.ModelPath = this.ModelPath;
+            copy.Units = this.Units;
+            copy.HasTimestampOverride = this.HasTimestampOverride;
+
+            return copy;
+        }
     }
 }

--- a/AdapterSdk/DataItems/DataItem.cs
+++ b/AdapterSdk/DataItems/DataItem.cs
@@ -426,5 +426,12 @@ namespace Mtconnect.AdapterSdk.DataItems
             hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(Value);
             return hashCode;
         }
+
+        /// <summary>
+        /// Copies the current DataItem into a new object.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public abstract DataItem Copy();
     }
 }

--- a/AdapterSdk/DataItems/Event.cs
+++ b/AdapterSdk/DataItems/Event.cs
@@ -74,5 +74,17 @@ namespace Mtconnect.AdapterSdk.DataItems
             };
             return true;
         }
+
+        /// <inheritdoc />
+        public override DataItem Copy()
+        {
+            var copy = new Event(this.Name, this.ObservationalType, this.ObservationalSubType, this.Description);
+            copy.FormatValue = this.FormatValue;
+            copy.ModelPath = this.ModelPath;
+            copy.Units = this.Units;
+            copy.HasTimestampOverride = this.HasTimestampOverride;
+
+            return copy;
+        }
     }
 }

--- a/AdapterSdk/DataItems/Message.cs
+++ b/AdapterSdk/DataItems/Message.cs
@@ -66,5 +66,18 @@ namespace Mtconnect.AdapterSdk.DataItems
             // TODO: Determine what needs to be validated from the Adapter
             return true;
         }
+
+        /// <inheritdoc />
+        public override DataItem Copy()
+        {
+            var copy = new Message(this.Name, this.Description, this.ObservationalType, this.ObservationalSubType);
+            copy.FormatValue = this.FormatValue;
+            copy.ModelPath = this.ModelPath;
+            copy.Units = this.Units;
+            copy.HasTimestampOverride = this.HasTimestampOverride;
+            copy.Code = this.Code;
+
+            return copy;
+        }
     }
 }

--- a/AdapterSdk/DataItems/Sample.cs
+++ b/AdapterSdk/DataItems/Sample.cs
@@ -55,5 +55,17 @@ namespace Mtconnect.AdapterSdk.DataItems
             };
             return true;
         }
+
+        /// <inheritdoc />
+        public override DataItem Copy()
+        {
+            var copy = new Sample(this.Name, this.ObservationalType, this.ObservationalSubType, this.Description);
+            copy.FormatValue = this.FormatValue;
+            copy.ModelPath = this.ModelPath;
+            copy.Units = this.Units;
+            copy.HasTimestampOverride = this.HasTimestampOverride;
+
+            return copy;
+        }
     }
 }

--- a/AdapterSdk/DataItems/TimeSeries.cs
+++ b/AdapterSdk/DataItems/TimeSeries.cs
@@ -110,5 +110,17 @@ namespace Mtconnect.AdapterSdk.DataItems
             // TODO: Determine what needs to be validated from the Adapter
             return true;
         }
+
+        /// <inheritdoc />
+        public override DataItem Copy()
+        {
+            var copy = new TimeSeries(this.Name, this.Description, this.Rate, this.ObservationalType, this.ObservationalSubType);
+            copy.FormatValue = this.FormatValue;
+            copy.ModelPath = this.ModelPath;
+            copy.Units = this.Units;
+            copy.HasTimestampOverride = this.HasTimestampOverride;
+
+            return copy;
+        }
     }
 }

--- a/AdapterSourceTemplate/AdvancedAdapterDataModelSource.cs
+++ b/AdapterSourceTemplate/AdvancedAdapterDataModelSource.cs
@@ -51,6 +51,13 @@ namespace Mtconnect.AdapterSourceTemplate
             Model.Availability = Availability.AVAILABLE;
 
             // TODO: Continue updating the Model with information.
+            if (!Model.Paths.ContainsKey("primary"))
+                Model.Paths.Add("primary", new Path());
+            Model.Paths["primary"].Execution = Execution.READY;
+            if (!Model.Paths.ContainsKey("secondary"))
+                Model.Paths.Add("secondary", new Path());
+            Model.Paths["secondary"].Execution = Execution.READY;
+
             // NOTE: The underlying Adapter will determine whether a value has changed, so no need to check for updated information.
 
             OnDataReceived?.Invoke(this, new DataReceivedEventArgs(Model));

--- a/AdapterSourceTemplate/Models/AdvancedAdapterDataModel.cs
+++ b/AdapterSourceTemplate/Models/AdvancedAdapterDataModel.cs
@@ -1,6 +1,7 @@
 ﻿using Mtconnect.AdapterSdk.Contracts.Attributes;
 using Mtconnect.AdapterSdk.DataItemTypes;
 using Mtconnect.AdapterSdk.DataItemValues;
+using System.Collections.Generic;
 
 namespace Mtconnect.AdapterSourceTemplate.Models
 {
@@ -12,6 +13,11 @@ namespace Mtconnect.AdapterSourceTemplate.Models
         [Event("avail")]
         public Availability Availability { get; set; }
 
+        [DataItemPartial("path")]
+        public Dictionary<string, Path> Paths { get; set; } = new Dictionary<string, Path>();
+    }
+    public sealed class Path : IAdapterDataModel
+    {
         [Event("exec")]
         public Execution Execution { get; set; }
     }

--- a/TcpTerminalTemplate/Program.cs
+++ b/TcpTerminalTemplate/Program.cs
@@ -17,7 +17,7 @@ namespace TcpTerminal
 
             using(var adapter = new TcpAdapter(options, loggerFactory))
             {
-                adapter.Start(new BasicAdapterDataModelSource());
+                adapter.Start(new AdvancedAdapterDataModelSource());
 
                 Task.Run(() => SaveDevices(adapter));
                 
@@ -33,7 +33,7 @@ namespace TcpTerminal
         }
         private static async void SaveDevices(TcpAdapter adapter)
         {
-            System.Threading.Thread.Sleep(5000);
+            System.Threading.Thread.Sleep(5_000);
             var dcf = new DeviceModelFactory();
             var doc = dcf.Create(adapter);
             string filename = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Devices.xml");

--- a/TcpTerminalTemplate/TcpTerminalTemplate.csproj
+++ b/TcpTerminalTemplate/TcpTerminalTemplate.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Consoul" Version="1.6.3" />
-    <PackageReference Include="Mtconnect.TcpAdapter" Version="2.0.0-beta.23" />
+    <PackageReference Include="Mtconnect.TcpAdapter" Version="2.0.4-beta-2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpiler/Properties/launchSettings.json
+++ b/Transpiler/Properties/launchSettings.json
@@ -3,6 +3,10 @@
     "Transpiler": {
       "commandName": "Project",
       "commandLineArgs": "\"../../../../AdapterSdk/Contracts\""
+    },
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
     }
   }
 }


### PR DESCRIPTION
Allow the processing of `Dictionary<string,>` and `List<>` properties within the `IAdapterDataModel`. For example:

```c#
public sealed class Model : IAdapterDataModel
{
  [Event("avail")]
  public Availability Availability { get; set; }
  
  [DataItemPartial("path_")]
  public Dictionary<string, Path> Paths { get; set; } = new Dictionary<string, Path>();
}

public sealed class path : IAdapterDataModel
{
  [Event("exec")]
  public Execution Execution { get; set; } = new Execution();
}

public static void Main()
{
  var model = new Model();
  model.Paths.Add("primary", new Path());
  model.Paths.Add("secondary", new Path());
}
```

This will result in three data items: `avail`, `path_primaryexec`, `path_secondaryexec`.