### PR TITLE
TimeSeries bug fix

### DIFF
--- a/AdapterSdk.Core/Contracts/DataItems/DataItem.cs
+++ b/AdapterSdk.Core/Contracts/DataItems/DataItem.cs
@@ -112,7 +112,7 @@ namespace Mtconnect.AdapterSdk.DataItems
         /// </summary>
         protected bool ValueValidated { get; set; } = false;
         /// <inheritdoc />
-        public object Value
+        public virtual object Value
         {
             set
             {
@@ -172,17 +172,20 @@ namespace Mtconnect.AdapterSdk.DataItems
         /// <inheritdoc />
         public Func<object, object> FormatValue { get; set; }
 
+        protected DataItem()
+        {
+            Unavailable();
+        }
+
         /// <summary>
         /// Create a new data item
         /// </summary>
         /// <param name="name"><inheritdoc cref="DataItem.Name" path="/summary"/></param>
         /// <param name="description"><inheritdoc cref="DataItem.Description" path="/summary"/></param>
-        public DataItem(string name, string description = null)
+        public DataItem(string name, string description = null) : this()
         {
             Name = name;
             Description = description;
-
-            Unavailable();
         }
 
         /// <summary>

--- a/AdapterSdk.Core/Contracts/DataItems/TimeSeries.cs
+++ b/AdapterSdk.Core/Contracts/DataItems/TimeSeries.cs
@@ -37,9 +37,36 @@ namespace Mtconnect.AdapterSdk.DataItems
 
                 _values = value;
 
-                Value = String.Join(" ", Values.Select(p => p.ToString()).ToArray());
+                base.Value = String.Join(" ", Values.Select(p => p.ToString()).ToArray());
             }
             get { return _values; } 
+        }
+
+        /// <inheritdoc />
+        public override object Value {
+            get { return _values; }
+            set {
+                if (value is double[])
+                {
+                    this.Values = value as double[];
+                } else if (value is TimeSeries)
+                {
+                    this.Values = (value as TimeSeries).Values;
+                } else
+                {
+                    throw new InvalidCastException("Cannot cast object to double[] or TimeSeries");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new TimeSeries entity, relying on the attributes to define the name, description, type, and subtype fields.
+        /// </summary>
+        /// <param name="rate"><inheritdoc cref="Rate" path="/summary"/></param>
+        public TimeSeries(double rate) : base()
+        {
+            HasNewLine = true;
+            Rate = rate;
         }
 
         /// <summary>

--- a/AdapterSdk/AdapterExtensions.cs
+++ b/AdapterSdk/AdapterExtensions.cs
@@ -228,7 +228,7 @@ namespace Mtconnect.AdapterSdk
                                     dataItem = new Condition(dataItemName, dataItemType, dataItemSubType, dataItemDescription);
                                     break;
                                 case TimeSeriesAttribute _:
-                                    dataItem = new TimeSeries(dataItemName, dataItemDescription, type: dataItemType, subType: dataItemSubType);
+                                    dataItem = new TimeSeries(dataItemName, dataItemDescription, rate: (propertyValue as TimeSeries)?.Rate ?? 0.0, type: dataItemType, subType: dataItemSubType);
                                     break;
                                 case MessageAttribute _:
                                     dataItem = new Message(dataItemName, dataItemDescription, dataItemType, dataItemSubType);

--- a/AdapterSdk/AdapterSdk.csproj
+++ b/AdapterSdk/AdapterSdk.csproj
@@ -13,15 +13,15 @@
     <Company>True Analytics Manufacturing Solutions</Company>
     <Product>MTConnect</Product>
     <Description>An interface library for connecting other libraries into the MtconnectCore.Adapter.</Description>
-    <Copyright>True Analytics Manufacturing Solutions, LLC 2023</Copyright>
+    <Copyright>True Analytics Manufacturing Solutions, LLC 2024</Copyright>
     <PackageIcon>icon.jpg</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>MTConnect;Adapter;Interface</PackageTags>
-    <PackageReleaseNotes>Added support for device model configuration with a MTConnect Agent.</PackageReleaseNotes>
+    <PackageReleaseNotes>Bug fix for TimeSeries data items</PackageReleaseNotes>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <PackageProjectUrl>https://github.com/TrueAnalyticsSolutions/MtconnectCore.Adapter</PackageProjectUrl>
     <RepositoryUrl>$(ProjectUrl)</RepositoryUrl>
-    <Version>3.0.1.1</Version>
+    <Version>3.0.1.2</Version>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<DebugSymbols>true</DebugSymbols>
@@ -77,9 +77,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.7.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.10.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Transpiler/Transpiler.csproj
+++ b/Transpiler/Transpiler.csproj
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Consoul" Version="1.6.3" />
+    <PackageReference Include="Consoul" Version="1.6.5" />
     <PackageReference Include="MtconnectTranspiler" Version="1.0.7" />
-    <PackageReference Include="MtconnectTranspiler.Sinks.CSharp" Version="1.0.12" />
+    <PackageReference Include="MtconnectTranspiler.Sinks.CSharp" Version="1.0.13" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 - Added empty constructor for DataItem
 - Added virtual keyword to DataItem.Value
 - Overwrote DataItem.Value in TimeSeries to utilize setter of TimeSeries.Values
 - Updated package references
 - Updated package version number.